### PR TITLE
skip releasing dict if it's nil

### DIFF
--- a/src/intc_dict.c
+++ b/src/intc_dict.c
@@ -60,5 +60,7 @@ intc_cli_t *intc_fetch_dict(const char *us_path, start_cli sf) {
 
 void intc_dispose_dict(close_cli cf) {
   _close_func = cf;
+  if (!_d) 
+    return;
   dictRelease(_d);
 }


### PR DESCRIPTION
dictRelease against a nil dict gonna cause a SIGSEGV issue.